### PR TITLE
Stop decision `restore_rum_caliphate` from being clicked infinitely

### DIFF
--- a/decisions/RestoreRomanEmpire.txt
+++ b/decisions/RestoreRomanEmpire.txt
@@ -112,6 +112,9 @@ country_decisions = {
 			}
 			NOT = { exists = RMC }
 			religion = ashabi
+            NOT = {
+                has_country_flag = restored_rome_flag
+            }
 		}
 		provinces_to_highlight = {
 			OR = {


### PR DESCRIPTION
Issue first raised [here](https://discord.com/channels/676465836575424572/1421875083743465492)